### PR TITLE
Add crop_resize_camera_info

### DIFF
--- a/tests/test_pinhole_camera.py
+++ b/tests/test_pinhole_camera.py
@@ -23,6 +23,12 @@ class TestPinholeCameraModel(unittest.TestCase):
     def setUpClass(cls):
         cls.cm = PinholeCameraModel.from_fovy(45, 480, 640)
 
+    def test_crop_resize_camra_info(self):
+        cropped_resized_cm = self.cm.crop_resize_camera_info(
+            target_size=[200, 100], roi=[0, 0, 100, 150])
+        testing.assert_equal(cropped_resized_cm.binning_x, 150 / 100.)
+        testing.assert_equal(cropped_resized_cm.binning_y, 100 / 200.)
+
     def test_crop_image(self):
         cropped_cm = copy.deepcopy(self.cm)
         cropped_cm.roi = [0, 0, 100, 100]


### PR DESCRIPTION
I added crop_resize_camera_info function to PinholeCameraModel class.
With this function, we can obtain the camera model in the resized range after cropping with a certain roi.
The default value of roi is self.roi. 

I used a normal camera model in the original image and a camera model obtained from this function in the resized image, and confirmed that the three-dimensional projected values ​​were almost the same.

```
camera_model_crop_resize = self.camera_model.crop_resize_camera_info(
    target_size=[256, 256])

hanging_point = np.array(camera_model_crop_resize.project_pixel_to_3d_ray(
    [int(hanging_point_x),
     int(hanging_point_y)]))

hanging_point_2 = np.array(
    self.camera_model.project_pixel_to_3d_ray(
        [int(hanging_point_x * (xmax - xmin) / 256),
         int(hanging_point_y * (ymax - ymin) / 256)]))

print(hanging_point, hanging_point_2)
# (array([0.0246514 , 0.30933984, 1.        ]), array([0.02406466, 0.30876866, 1.        ]))
```