### PR TITLE
Fixed binning of crop_resize_camera_info

### DIFF
--- a/cameramodels/pinhole_camera.py
+++ b/cameramodels/pinhole_camera.py
@@ -847,8 +847,8 @@ class PinholeCameraModel(object):
 
         roi = self.roi if roi is None else roi
 
-        binning_x = roi[3] / target_size[1]
-        binning_y = roi[2] / target_size[0]
+        binning_x = (roi[3] - roi[1]) / target_size[1]
+        binning_y = (roi[2] - roi[0]) / target_size[0]
 
         return PinholeCameraModel(
             self.height, self.width,


### PR DESCRIPTION
Sorry for my mistakes.
In #19 I was mistaken for roi as [y_offset, x_offset, height, width], but correctly it was [left_y, left_x, right_y, right_x].
The documentation is fine.