### PR TITLE
Add crop_resize_image function

### DIFF
--- a/cameramodels/pinhole_camera.py
+++ b/cameramodels/pinhole_camera.py
@@ -834,7 +834,7 @@ class PinholeCameraModel(object):
         target_size : list[int]
             [target_width, target_height] order.
         roi : list[float]
-            [left_y, left_x, right_y, right_x] order, by default self.roi.
+            [top, left, bottom, right] order, by default self.roi.
 
         Returns
         -------
@@ -847,8 +847,15 @@ class PinholeCameraModel(object):
 
         roi = self.roi if roi is None else roi
 
-        binning_x = (roi[3] - roi[1]) / target_size[1]
-        binning_y = (roi[2] - roi[0]) / target_size[0]
+        roi_height = roi[2] - roi[0]
+        roi_width = roi[3] - roi[1]
+        if roi_height <= 0 or roi_width <= 0:
+            raise ValueError(
+                "Invalid ROI, [left: {}, top: {}, right: {}, bottom: {}]".
+                format(roi[0], roi[1], roi[2], roi[3]))
+
+        binning_x = roi_width / target_size[1]
+        binning_y = roi_height / target_size[0]
 
         return PinholeCameraModel(
             self.height, self.width,

--- a/cameramodels/pinhole_camera.py
+++ b/cameramodels/pinhole_camera.py
@@ -75,7 +75,8 @@ class PinholeCameraModel(object):
                  full_height=None,
                  full_width=None,
                  binning_x=1,
-                 binning_y=1):
+                 binning_y=1,
+                 target_size=None):
         self._width = image_width
         self._height = image_height
         self._full_width = full_width or self._width
@@ -97,11 +98,36 @@ class PinholeCameraModel(object):
             self._full_P = self.P.copy()
         self._fovx = 2.0 * np.rad2deg(np.arctan(self.width / (2.0 * self.fx)))
         self._fovy = 2.0 * np.rad2deg(np.arctan(self.height / (2.0 * self.fy)))
-        self.binning_x = binning_x
-        self.binning_y = binning_y
-        self.roi = roi or [0, 0, self._height, self._width]
+        self._binning_x = binning_x
+        self._binning_y = binning_y
+        self._roi = roi or [0, 0, self._height, self._width]
+        self._target_size = target_size
         self.tf_frame = tf_frame
         self.stamp = stamp
+
+        # finally calculate K and P considering ROI and binning.
+        self._adjust()
+
+    def _adjust(self):
+        """Adjust K and P for binning and ROI
+
+        """
+        y1, x1, y2, x2 = self.roi
+        K = self.full_K.copy()
+        P = self.full_P.copy()
+        # Adjust K and P for binning and ROI
+        K[0, 0] /= self._binning_x
+        K[1, 1] /= self._binning_y
+        K[0, 2] = (K[0, 2] - x1) / self._binning_x
+        K[1, 2] = (K[1, 2] - y1) / self._binning_y
+        P[0, 0] /= self._binning_x
+        P[1, 1] /= self._binning_y
+        P[0, 2] = (P[0, 2] - x1) / self._binning_x
+        P[1, 2] = (P[1, 2] - y1) / self._binning_y
+        self.K = K
+        self.P = P
+        self._width = x2 - x1
+        self._height = y2 - y1
 
     @property
     def width(self):
@@ -381,15 +407,25 @@ class PinholeCameraModel(object):
         return self._binning_x
 
     @binning_x.setter
-    def binning_x(self, decimation_x):
+    def binning_x(self, binning_x):
         """Setter of binning_x
+
+        Note that this setter internally changes target_size, K and P.
 
         Parameters
         -----------
-        decimation_x : int
+        binning_x : float
             decimation value.
         """
-        self._binning_x = decimation_x
+        if binning_x <= 0:
+            raise ValueError("binning should be greater than 0.")
+        self._binning_x = binning_x
+        roi_width = self.roi[3] - self.roi[1]
+        _, target_height = self._target_size
+        target_width = int(roi_width / binning_x)
+        self._binning_x = roi_width / target_width
+        self._target_size = (target_width, target_height)
+        self._adjust()
 
     @property
     def binning_y(self):
@@ -403,15 +439,57 @@ class PinholeCameraModel(object):
         return self._binning_y
 
     @binning_y.setter
-    def binning_y(self, decimation_y):
+    def binning_y(self, binning_y):
         """Setter of binning_y
+
+        Note that this setter internally changes target_size, K and P.
 
         Parameters
         -----------
-        decimation_y : int
+        binning_y : float
             decimation value.
         """
-        self._binning_y = decimation_y
+        if binning_y <= 0:
+            raise ValueError("binning should be greater than 0.")
+        self._binning_y = binning_y
+        roi_height = self.roi[2] - self.roi[0]
+        target_width, _ = self._target_size
+        target_height = int(roi_height / binning_y)
+        self._binning_y = roi_height / target_height
+        self._target_size = (target_width, target_height)
+        self._adjust()
+
+    @property
+    def target_size(self):
+        """Return target_size
+
+        Returns
+        -------
+        self._target_size : None or tuple(int)
+            (width, height).
+            If this value is `None`, target size is not specified.
+        """
+        return self._target_size
+
+    @target_size.setter
+    def target_size(self, target_size):
+        """Setter of target_size
+
+        This setter internally changes value of binning_x, binning_y, K and P.
+
+        Parameters
+        ----------
+        target_size : tuple(int)
+            (width, height)
+        """
+        if len(target_size) != 2:
+            raise ValueError('target_size length should be 2')
+        roi_height = self.roi[2] - self.roi[0]
+        roi_width = self.roi[3] - self.roi[1]
+        self._binning_x = roi_width / target_size[1]
+        self._binning_y = roi_height / target_size[0]
+        self._target_size = target_size
+        self._adjust()
 
     @property
     def roi(self):
@@ -433,26 +511,8 @@ class PinholeCameraModel(object):
         roi : list[float]
             [left_y, left_x, right_y, right_x] order.
         """
-        y1, x1, y2, x2 = roi
-        K = self.full_K.copy()
-        P = self.full_P.copy()
-        # Adjust K and P for binning and ROI
-        K[0, 0] /= self._binning_x
-        K[1, 1] /= self._binning_y
-        K[0, 2] = (K[0, 2] - x1) / self._binning_x
-        K[1, 2] = (K[1, 2] - y1) / self._binning_y
-        P[0, 0] /= self._binning_x
-        P[1, 1] /= self._binning_y
-        P[0, 2] = (P[0, 2] - x1) / self._binning_x
-        P[1, 2] = (P[1, 2] - y1) / self._binning_y
-
-        height = y2 - y1
-        width = x2 - x1
-        self.K = K
-        self.P = P
-        self._width = width
-        self._height = height
         self._roi = roi
+        self._adjust()
 
     @property
     def open3d_intrinsic(self):
@@ -803,15 +863,6 @@ class PinholeCameraModel(object):
 
         full_K = K.copy()
         full_P = P.copy()
-        # Adjust K and P for binning and ROI
-        K[0, 0] /= binning_x
-        K[1, 1] /= binning_y
-        K[0, 2] = (K[0, 2] - raw_roi.x_offset) / binning_x
-        K[1, 2] = (K[1, 2] - raw_roi.y_offset) / binning_y
-        P[0, 0] /= binning_x
-        P[1, 1] /= binning_y
-        P[0, 2] = (P[0, 2] - raw_roi.x_offset) / binning_x
-        P[1, 2] = (P[1, 2] - raw_roi.y_offset) / binning_y
         return PinholeCameraModel(
             raw_roi.height, raw_roi.width,
             K, P, R, D,
@@ -854,8 +905,8 @@ class PinholeCameraModel(object):
                 "Invalid ROI, [left: {}, top: {}, right: {}, bottom: {}]".
                 format(roi[0], roi[1], roi[2], roi[3]))
 
-        binning_x = roi_width / target_size[1]
-        binning_y = roi_height / target_size[0]
+        binning_x = roi_width / target_size[0]
+        binning_y = roi_height / target_size[1]
 
         return PinholeCameraModel(
             self.height, self.width,
@@ -869,10 +920,13 @@ class PinholeCameraModel(object):
             full_height=self._full_height,
             full_width=self._full_width,
             binning_x=binning_x,
-            binning_y=binning_y)
+            binning_y=binning_y,
+            target_size=target_size)
 
     def crop_image(self, img, copy=False):
         """Crop input full resolution image considering roi.
+
+        Note that this function will not return resized image.
 
         Parameters
         ----------

--- a/tests/test_pinhole_camera.py
+++ b/tests/test_pinhole_camera.py
@@ -25,7 +25,7 @@ class TestPinholeCameraModel(unittest.TestCase):
 
     def test_crop_resize_camra_info(self):
         cropped_resized_cm = self.cm.crop_resize_camera_info(
-            target_size=[200, 100], roi=[0, 0, 100, 150])
+            target_size=[100, 200], roi=[0, 0, 100, 150])
         testing.assert_equal(cropped_resized_cm.binning_x, 150 / 100.)
         testing.assert_equal(cropped_resized_cm.binning_y, 100 / 200.)
 
@@ -123,6 +123,30 @@ class TestPinholeCameraModel(unittest.TestCase):
         alpha_img = alpha_img_org.copy()
         cm.draw_roi(alpha_img, copy=True)
         testing.assert_equal(alpha_img, alpha_img_org)
+
+    def test__binning_x(self):
+        cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
+        cm.roi = [0, 0, 100, 100]
+        cm.target_size = (256, 256)
+        cm.binning_x = 0.5
+        self.assertEqual(cm.target_size, (200, 256))
+
+        cm.target_size = (256, 256)
+        cm.roi = [0, 0, 100, 97]
+        cm.binning_x = 2
+        self.assertEqual(cm.target_size, (48, 256))
+
+    def test__binning_y(self):
+        cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
+        cm.roi = [0, 0, 100, 100]
+        cm.target_size = (256, 256)
+        cm.binning_y = 0.5
+        self.assertEqual(cm.target_size, (256, 200))
+
+        cm.target_size = (256, 256)
+        cm.roi = [0, 0, 97, 100]
+        cm.binning_y = 2
+        self.assertEqual(cm.target_size, (256, 48))
 
     def test__roi(self):
         cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())

--- a/tests/test_pinhole_camera.py
+++ b/tests/test_pinhole_camera.py
@@ -47,6 +47,26 @@ class TestPinholeCameraModel(unittest.TestCase):
         with self.assertRaises(ValueError):
             cropped_cm.crop_image(np.zeros((100, 100)))
 
+    def test_crop_resize_image(self):
+        cropped_cm = copy.deepcopy(self.cm)
+        cropped_cm.roi = [0, 0, 100, 100]
+        gray_img = np.zeros((480, 640), dtype=np.uint8)
+        cropped_cm.target_size = (256, 256)
+        ret_img = cropped_cm.crop_resize_image(gray_img)
+        testing.assert_equal(ret_img.shape, (256, 256))
+
+        bgr_img = np.zeros((480, 640, 3), dtype=np.uint8)
+        cropped_cm.target_size = (10, 10)
+        ret_img = cropped_cm.crop_resize_image(bgr_img)
+        testing.assert_equal(ret_img.shape, (10, 10, 3))
+
+        with self.assertRaises(ValueError):
+            cropped_cm.crop_resize_image(np.zeros(100))
+
+        with self.assertRaises(ValueError):
+            cropped_cm.crop_resize_image(
+                np.zeros((100, 100), dtype=np.uint8))
+
     def test_calc_f_from_fov(self):
         f = PinholeCameraModel.calc_f_from_fov(90, 480)
         testing.assert_almost_equal(

--- a/tests/test_pinhole_camera.py
+++ b/tests/test_pinhole_camera.py
@@ -29,6 +29,11 @@ class TestPinholeCameraModel(unittest.TestCase):
         testing.assert_equal(cropped_resized_cm.binning_x, 150 / 100.)
         testing.assert_equal(cropped_resized_cm.binning_y, 100 / 200.)
 
+        with self.assertRaises(ValueError):
+            # invalid roi
+            cropped_resized_cm = self.cm.crop_resize_camera_info(
+                target_size=[200, 100], roi=[200, 0, 100, 150])
+
     def test_crop_image(self):
         cropped_cm = copy.deepcopy(self.cm)
         cropped_cm.roi = [0, 0, 100, 100]


### PR DESCRIPTION
To extract target_size image, added a crop_resize_image function.

## Example
```
import cv2

from cameramodels import PinholeCameraModel
from cameramodels.data import kinect_v2_camera_info
from cameramodels.data import kinect_v2_image


cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
cm.target_size = (256, 256)
img = kinect_v2_image()
out = cm.crop_resize_image(img)
print("out.shape = {}".format(out.shape))
cv2.imshow('img', out)
cv2.waitKey()
cv2.destroyAllWindows()
```