### PR TITLE
Add points_in_roi function

### DIFF
--- a/cameramodels/pinhole_camera.py
+++ b/cameramodels/pinhole_camera.py
@@ -1352,3 +1352,26 @@ class PinholeCameraModel(object):
             np_pil_img = np.array(pil_img, dtype=img.dtype)
             bgr_img[:] = np_pil_img[..., rgb_to_bgr_indices]
             return bgr_img
+
+    def points_in_roi(self, points):
+        """Check if input points are in roi.
+
+        Parameters
+        ----------
+        points : list[list[float, float]]
+            [[x_1, y_1], [x_2, y_2] ..., [x_n, y_n]].
+
+        Returns
+        -------
+        result list[bool]
+            True if the point is in roi, False otherwise.
+        """
+        result = []
+        for point in points:
+            if self.roi[1] <= point[0] <= self.roi[3] \
+               and self.roi[0] <= point[1] <= self.roi[2]:
+                result.append(True)
+            else:
+                result.append(False)
+
+        return result

--- a/tests/test_pinhole_camera.py
+++ b/tests/test_pinhole_camera.py
@@ -144,6 +144,19 @@ class TestPinholeCameraModel(unittest.TestCase):
         cm.draw_roi(alpha_img, copy=True)
         testing.assert_equal(alpha_img, alpha_img_org)
 
+    def test_points_roi(self):
+        cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
+        points = [[874.5, 680],
+                  [875, 680],
+                  [875, 679.5],
+                  [1072, 680],
+                  [1072.5, 680],
+                  [1072, 859],
+                  [1072, 869.5]]
+        testing.assert_equal(
+            cm.points_in_roi(points),
+            [False, True, False, True, False, True, False])
+
     def test__target_size(self):
         cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
         cm.target_size = (640, 480)


### PR DESCRIPTION
In this PR, I added a function to check if the points are in roi.

```
from cameramodels import PinholeCameraModel
from cameramodels.data import kinect_v2_camera_info

cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())

# cm.roi [680, 875, 859, 1072]
# roi is [top, left, bottom, right] and point is x, y order.
points = [[874.5, 680],
          [875, 680],
          [875, 679.5],
          [1072, 680],
          [1072.5, 680],
          [1072, 859],
          [1072, 869.5]]

result = cm.points_in_roi(points)
print(result)
# [False, True, False, True, False, True, False]

# gt = [False, True, False, True, False, True, False]
```