### PR TITLE
Fixed a bug that name is None in from_yaml_file

### DIFF
--- a/cameramodels/pinhole_camera.py
+++ b/cameramodels/pinhole_camera.py
@@ -778,7 +778,7 @@ class PinholeCameraModel(object):
             D = data['distortion_coefficients']['data']
             distortion_model = 'plumb_bob'
             if 'camera_name' in data:
-                name = data['camera_name']
+                name = data['camera_name'] or ''
             else:
                 name = ''
         elif 'width' in data:


### PR DESCRIPTION
In this PR, I fixed a bug that when loading a dumped yaml the camera name was none and it couldn't dump again.

```
from cameramodels import PinholeCameraModel
from cameramodels.data import kinect_v2_camera_info

cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
# cm.name is ''
cm.dump('hoge.yaml')
cm = PinholeCameraModel.from_yaml_file('hoge.yaml')
# cm.name is None
cm.dump('hoge.yaml')

'''
--------------------------------------------------------------------
TypeError                          Traceback (most recent call last)
<ipython-input-13-2963461dbd5b> in <module>
----> 1 cm.dump('hoge.yaml')

~/.pyenv/versions/anaconda3-2019.10/lib/python3.7/site-packages/cameramodels/pinhole_camera.py in dump(self, output_filepath)
   1331                 "image_width: %d" % self._full_width,
   1332                 "image_height: %d" % self._full_height,
-> 1333                 "camera_name: " + self.name,
   1334                 "camera_matrix:",
   1335                 "  rows: 3",

TypeError: can only concatenate str (not "NoneType") to str
'''
```