### PR TITLE
Adjust binning

### DIFF
--- a/cameramodels/pinhole_camera.py
+++ b/cameramodels/pinhole_camera.py
@@ -144,6 +144,9 @@ class PinholeCameraModel(object):
         K = self.full_K.copy()
         P = self.full_P.copy()
         # Adjust K and P for binning and ROI
+        if self._target_size is not None:
+            self._binning_x = (x2 - x1) / self._target_size[0]
+            self._binning_y = (y2 - y1) / self._target_size[1]
         K[0, 0] /= self._binning_x
         K[1, 1] /= self._binning_y
         K[0, 2] = (K[0, 2] - x1) / self._binning_x

--- a/tests/test_pinhole_camera.py
+++ b/tests/test_pinhole_camera.py
@@ -192,8 +192,18 @@ class TestPinholeCameraModel(unittest.TestCase):
 
     def test__target_size(self):
         cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
+        org_roi = copy.deepcopy(cm.roi)
         cm.target_size = (640, 480)
         self.assertEqual(cm.target_size, (640, 480))
+
+        resize_K = cm.K.copy()
+        resize_P = cm.P.copy()
+
+        cm.roi = [0, 0, 100, 100]
+        cm.target_size = (640, 480)
+        cm.roi = org_roi
+        testing.assert_equal(resize_K, cm.K)
+        testing.assert_equal(resize_P, cm.P)
 
     def test__binning_x(self):
         cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())


### PR DESCRIPTION
Fixed to adjust binning. Without this pr, setting the target size and then the roi will not give the correct K and P matrix.

```
import numpy as np
from cameramodels import PinholeCameraModel
from cameramodels.data import kinect_v2_camera_info

cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
roi = cm.roi  # [680, 875, 859, 1072]
cm.target_size = [256, 256]
K_0 = cm.K
P_0 = cm.P

cm = PinholeCameraModel.from_yaml_file(kinect_v2_camera_info())
cm.roi = [0, 0, 1080, 1920]
cm.target_size = [256, 256]
cm.roi = roi
K_1 = cm.K
P_1 = cm.P

print(np.all(K_0 == K_1) and np.all(P_0 == P_1))
```